### PR TITLE
Add a pre-run of the jar at build time to make it download libraries earlier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,5 @@ ENV JAVA_XMX 1G
 COPY ./app/ /app/
 
 ENTRYPOINT ["/app/entrypoint.sh"]
+
+RUN /app/entrypoint.sh --version


### PR DESCRIPTION
speeds up boot depending on networking/etc, and should make the container more predictable run on run.